### PR TITLE
Cmake builds, Docker, and CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# Build directory (cmake out of source)
+build/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,3 +3,21 @@ cmake_minimum_required(VERSION 3.9)
 project(forest)
 
 install(DIRECTORY forest DESTINATION include FILES_MATCHING PATTERN "*.h")
+
+include_directories(.)
+
+add_executable(bsearch
+  examples/example_binary_search_tree.cpp)
+
+add_executable(rbtree
+  examples/example_red_black_tree.cpp)
+
+add_executable(stree
+  examples/example_splay_tree.cpp)
+
+add_executable(forest_test
+  tests/test.cpp
+  tests/catch.hpp
+  tests/test_binary_search_tree.cpp
+  tests/test_red_black_tree.cpp
+  tests/test_splay_tree.cpp)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
 FROM quay.io/jlospinoso/cppbuild:v1.0.0
-RUN apt update && apt upgrade -y
 
 RUN mkdir forest
 WORKDIR forest
-
 COPY *.h *.hpp *.cpp CMakeLists.txt examples tests ./
 RUN mkdir build
 WORKDIR build

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/jlospinoso/cppbuild:v1.0.0
 
 RUN mkdir forest
 WORKDIR forest
-COPY *.h *.hpp *.cpp CMakeLists.txt examples tests ./
+COPY / ./
 RUN mkdir build
 WORKDIR build
 RUN cmake ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM quay.io/jlospinoso/cppbuild:v1.0.0
+RUN apt update && apt upgrade -y
+
+RUN mkdir forest
+WORKDIR forest
+
+COPY *.h *.hpp *.cpp CMakeLists.txt ./
+RUN mkdir build
+WORKDIR build
+RUN cmake ..
+RUN make

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt upgrade -y
 RUN mkdir forest
 WORKDIR forest
 
-COPY *.h *.hpp *.cpp CMakeLists.txt ./
+COPY *.h *.hpp *.cpp CMakeLists.txt ./ examples tests
 RUN mkdir build
 WORKDIR build
 RUN cmake ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt update && apt upgrade -y
 RUN mkdir forest
 WORKDIR forest
 
-COPY *.h *.hpp *.cpp CMakeLists.txt ./ examples tests
+COPY *.h *.hpp *.cpp CMakeLists.txt examples tests ./
 RUN mkdir build
 WORKDIR build
 RUN cmake ..

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ![forest logo](https://i.imgur.com/zl44kiK.jpg)
 
+[![CircleCI](https://circleci.com/gh/JLospinoso/forest/tree/master.svg?style=svg)](https://circleci.com/gh/JLospinoso/forest/tree/master)
+
 Forest is an open source, template library of tree data structures written in C++11.
 
 ## Installation

--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,7 @@ compile:
 
 test:
   override:
-    - docker run xorz57/forest --entrypoint ./bsearch
-    - docker run xorz57/forest --entrypoint ./rbtree
-    - docker run xorz57/forest --entrypoint ./stree
-    - docker run xorz57/forest --entrypoint ./forest_test
+    - docker run xorz57/forest ./bsearch
+    - docker run xorz57/forest ./rbtree
+    - docker run xorz57/forest ./stree
+    - docker run xorz57/forest ./forest_test

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,18 @@
+machine:
+  services:
+    - docker
+
+dependencies:
+  override:
+    - docker info
+
+compile:
+  override:
+    - docker build --rm=false -t xorz57/forest:latest .
+
+test:
+  override:
+    - docker run xorz57/forest --entrypoint ./bsearch
+    - docker run xorz57/forest --entrypoint ./rbtree
+    - docker run xorz57/forest --entrypoint ./stree
+    - docker run xorz57/forest --entrypoint ./forest_test


### PR DESCRIPTION
Implements #17 #19 and #20 

1. You can now build from a Docker container (see Dockerfile)
2. Build runs on CircleCI, but you can extend to other platforms easily now (because Docker..)
3. You'll want to set up your own CircleCI account to manage builds--right now it's working off my fork (https://circleci.com/gh/JLospinoso/forest)
4. I added a badge to README, update the URL as appropriate once you've got your account
5. Examples and tests now build