### PR TITLE
[CMake] Add default build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.9)
 
 project(forest)
 
+# Let CMake find custom modules
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
+
+include(ForestBuildType)
+
 set (CMAKE_CXX_STANDARD 11)
 
 install(DIRECTORY forest DESTINATION include FILES_MATCHING PATTERN "*.h")

--- a/cmake/modules/ForestBuildType.cmake
+++ b/cmake/modules/ForestBuildType.cmake
@@ -1,0 +1,16 @@
+# Source: https://blog.kitware.com/cmake-and-the-default-build-type
+
+# Set a default build type if none was specified
+set(default_build_type "Release")
+if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    set(default_build_type "Debug")
+endif()
+
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
+    set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
+        STRING "Choose the type of build." FORCE)
+    # Set the possible values of build type for cmake-gui
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS
+        "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+endif()


### PR DESCRIPTION
Add default build type.

This is a part of a series of PRs aimed at better CMake support. In order to not introduce merge conflicts, this should be merged until other CMake-related PRs are introduced.

References: #48