### PR TITLE
Fix Catch header download

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,12 @@ execute_process(
     OUTPUT_QUIET
     ERROR_QUIET)
 
+file(STRINGS "${CMAKE_CURRENT_BINARY_DIR}/catch.hpp"
+      catch_version
+    REGEX " \*  Catch v")
+
+message(STATUS "${catch_version}")
+
 # Generate main test file
 file(
     WRITE

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,12 @@
 project(forestTests LANGUAGES CXX)
 
 message(STATUS "Downloading Catch header")
-file(
-    DOWNLOAD
-      https://raw.githubusercontent.com/philsquared/Catch/master/single_include/catch.hpp
-      "${CMAKE_CURRENT_BINARY_DIR}/catch.hpp")
+# External curl is used due to CMake not being built with SSL by default
+execute_process(
+    COMMAND
+      curl -o "${CMAKE_CURRENT_BINARY_DIR}/catch.hpp" https://raw.githubusercontent.com/philsquared/Catch/master/single_include/catch.hpp
+    OUTPUT_QUIET
+    ERROR_QUIET)
 
 # Generate main test file
 file(


### PR DESCRIPTION
Use system curl instead of bundled one. External curl is used due to CMake not being built with SSL by default.

Also displays Catch framework version.