### PR TITLE
[CMake] Remove copyright notice

### DIFF
--- a/cmake/forestConfig.cmake
+++ b/cmake/forestConfig.cmake
@@ -1,7 +1,1 @@
-# Copyright (C) 2017 Oleksii Vilchanskyi <alexvilchansky@yahoo.com>
-#
-# This software may be modified and distributed under the terms
-# of the MIT license.  See the LICENSE file for details.
-#
-
 include("${CMAKE_CURRENT_LIST_DIR}/forestTargets.cmake")


### PR DESCRIPTION
References a294243. That commit missed one notice, this one fixes it.