### PR TITLE
Trying to speed up travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,50 +1,39 @@
-language: cpp 
 dist: trusty
-matrix:
-  include:
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-      env:
-        - MATRIX_EVAL="CXX=g++-4.9"
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-5
-      env:
-        - MATRIX_EVAL="CXX=g++-5"
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-6
-      env:
-        - MATRIX_EVAL="CXX=g++-6"
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-7
-      env:
-        - MATRIX_EVAL="CXX=g++-7"
+language: cpp
+
+git:
+  depth: 1 # download only last commit
+env:
+  global:
+    - MAKEFLAGS="-j 2"
+
+cache: apt
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+
 install:
-  - sudo pip install codecov
-before_script:
-  - eval "${MATRIX_EVAL}"
+  - export DEBIAN_FRONTEND=noninteractive
+  - sudo -E apt-get -yq update &>> ~/apt-get-update.log
+  - sudo -E apt-get -yq --no-install-suggests --no-install-recommends --force-yes install g++-${GPP_VERSION}
+  - pip install --user codecov
+
 script:
+  - export CXX=g++-${GPP_VERSION}
   - curl -o include/catch.hpp -O https://raw.githubusercontent.com/catchorg/Catch2/master/single_include/catch.hpp
   - bash build_tests.sh
   - bash run_tests.sh
-after_success:
   - cd tests && codecov
+
+
+jobs:
+  include:
+    - stage: test
+      env: GPP_VERSION=4.9
+    - stage: test
+      env: GPP_VERSION=5
+    - stage: test
+      env: GPP_VERSION=6
+    - stage: test
+      env: GPP_VERSION=7

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,41 +1,21 @@
 CXXFLAGS=-std=c++14 -Wall -Werror
+# Source files extension
+SOURCE_EXT=cpp
+# Find all files with wanted extension
+SOURCES:=$(foreach ext, $(SOURCE_EXT), $(wildcard *.$(ext)))
+# Destination extension
+OBJ_EXT=o
+# Object files with wanted extension (converts for example test_trie.cpp to test_trie.o)
+OBJECT_FILES:=$(foreach source, $(SOURCES), $(addsuffix .$(OBJ_EXT),$(basename $(source))))
+# Destination files without extension
+DESTINATION:=$(foreach source, $(SOURCES), $(basename $(source)))
 
-all: example_binary_search_tree example_avl_tree example_splay_tree example_red_black_tree example_trie
+all: ${DESTINATION}
 
-example_binary_search_tree: example_binary_search_tree.o
-	$(CXX) example_binary_search_tree.o $(CXXFLAGS) -o example_binary_search_tree
-
-example_avl_tree: example_avl_tree.o
-	$(CXX) example_avl_tree.o $(CXXFLAGS) -o example_avl_tree
-
-example_splay_tree: example_splay_tree.o
-	$(CXX) example_splay_tree.o $(CXXFLAGS) -o example_splay_tree
-
-example_red_black_tree: example_red_black_tree.o
-	$(CXX) example_red_black_tree.o $(CXXFLAGS) -o example_red_black_tree
-
-example_trie: example_trie.o
-	$(CXX) example_trie.o $(CXXFLAGS) -o example_trie
-
-example_binary_search_tree.o: example_binary_search_tree.cpp
-	$(CXX) -c example_binary_search_tree.cpp $(CXXFLAGS) -I ../include
-
-example_avl_tree.o: example_avl_tree.cpp
-	$(CXX) -c example_avl_tree.cpp $(CXXFLAGS) -I ../include
-
-example_splay_tree.o: example_splay_tree.cpp
-	$(CXX) -c example_splay_tree.cpp $(CXXFLAGS) -I ../include
-
-example_red_black_tree.o: example_red_black_tree.cpp
-	$(CXX) -c example_red_black_tree.cpp $(CXXFLAGS) -I ../include
-
-example_trie.o: example_trie.cpp
-	$(CXX) -c example_trie.cpp $(CXXFLAGS) -I ../include
+# For a given destination executable, build it from its cpp source
+%:%.cpp
+	$(CXX) $(CXXFLAGS) -I ../include -o $@ $<
 
 clean:
-	rm -f *.o
-	rm -f example_binary_search_tree
-	rm -f example_avl_tree
-	rm -f example_splay_tree
-	rm -f example_red_black_tree
-	rm -f example_trie
+	rm -f ${OBJECT_FILES}
+	rm -f ${DESTINATION}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,25 +1,20 @@
 CXXFLAGS=-std=c++14 -Wall -Werror --coverage
+# Source files extension
+SOURCE_EXT=cpp
+# Find all files with wanted extension
+SOURCES:=$(foreach ext, $(SOURCE_EXT), $(wildcard *.$(ext)))
+# Destination extension
+DEST_EXT=o
+# Destination files with wanted extension (converts for example test_trie.cpp to test_trie.o)
+DESTINATIONS:=$(foreach source, $(SOURCES), $(addsuffix .$(DEST_EXT),$(basename $(source))))
 
-test: test_main.o test_binary_search_tree.o test_avl_tree.o test_splay_tree.o test_red_black_tree.o test_trie.o
-	$(CXX) test_main.o test_binary_search_tree.o test_avl_tree.o test_splay_tree.o test_red_black_tree.o test_trie.o $(CXXFLAGS) -o test
+# Build and then test all destination files
+test: ${DESTINATIONS}
+	$(CXX) ${DESTINATIONS} $(CXXFLAGS) -o test
 
-test_main.o: test_main.cpp
-	$(CXX) -c test_main.cpp $(CXXFLAGS) -I ../include
-
-test_binary_search_tree.o: test_binary_search_tree.cpp
-	$(CXX) -c test_binary_search_tree.cpp $(CXXFLAGS) -I ../include
-
-test_avl_tree.o: test_avl_tree.cpp
-	$(CXX) -c test_avl_tree.cpp $(CXXFLAGS) -I ../include
-
-test_splay_tree.o: test_splay_tree.cpp
-	$(CXX) -c test_splay_tree.cpp $(CXXFLAGS) -I ../include
-
-test_red_black_tree.o: test_red_black_tree.cpp
-	$(CXX) -c test_red_black_tree.cpp $(CXXFLAGS) -I ../include
-
-test_trie.o: test_trie.cpp
-	$(CXX) -c test_trie.cpp $(CXXFLAGS) -I ../include
+# For a given destination file using .o extension, build it from its cpp source
+%.o: %.cpp ## Converts from cpp to object
+	$(CXX) -c $< $(CXXFLAGS) -I ../include
 
 clean:
 	rm -f *.o


### PR DESCRIPTION
I made a little progresses, check my `.travis.yml` file and there: https://travis-ci.org/73VW/forest/builds/364973834

I managed to speed up a little bit the build by downloading only last commit. You don't need more because you are just building and testing. I also changed the makeflags to use both Travis cores and it doesn't seem to make troubles. Moreover I have upgraded your config to use Travis build stages which allows you to add one more step if you ever need to deploy anything.

I have also updated your  test Makefile to make it more reusable. It tests all the files in the `test` directory.

The only problem I can actually see is that `g++-7` weights 107mb when other version weight around 35mb so it takes much more time to download. I don't really know how to speed up this because you can't cache installed packages (which would be really usefull in this case).

If you have any more questions, feel free to ask.

Cheers